### PR TITLE
Change Email URL to show the full URL

### DIFF
--- a/Support/bin/create_task
+++ b/Support/bin/create_task
@@ -21,6 +21,6 @@ on run argv
 		-- set tag names of newToDo to "Work"
 
 		-- properties can include, for example, 'tag names:"Work"', but I couldn't make that work...
-		show quick entry panel with properties {name:theName, notes:theMessage & "\n\n–\n\n" & theNote}
+		show quick entry panel with properties {name:theName, notes:theMessage & "\n–\n\n" & theNote}
 	end tell
 end run

--- a/Support/bin/create_task
+++ b/Support/bin/create_task
@@ -11,7 +11,7 @@ on run argv
 		set theNote to ""
 	end try
 
-	set theMessage to "[url=" & theURL & "]Email[/url]"
+	set theMessage to "Email: " & theURL
 
 	tell application id "com.culturedcode.ThingsMac"
 		-- Creating a todo without the quick entry:
@@ -21,6 +21,6 @@ on run argv
 		-- set tag names of newToDo to "Work"
 
 		-- properties can include, for example, 'tag names:"Work"', but I couldn't make that work...
-		show quick entry panel with properties {name:theName, notes:theMessage & "\n" & theNote}
+		show quick entry panel with properties {name:theName, notes:theMessage & "\n\n–\n\n" & theNote}
 	end tell
 end run


### PR DESCRIPTION
Not sure if this is something you care to change, and this is probably more of a personal preference... but I like to be able to script the notes field based on the URLs and having the URL encoded into rich-text means I can't extract that to take action on it.

Anyway, this makes the Email URL reference match what you have in OmniFocus.

Example of the changed note field:
```
Email: message://%3c4WTiSNUIEsHlOgGg4dJ4QQ%40ismtpd078504d1iad1.sendgrid.net%3e
–

From: "Matt D. Smith" <matt@google.com>
Subject: hey

Additional email details here.
```