### PR TITLE
Instant Add to Things

### DIFF
--- a/Commands/Instant Add With Summary.mmCommand
+++ b/Commands/Instant Add With Summary.mmCommand
@@ -4,5 +4,5 @@
 	environment   = 'MM_FROM=${from}\nMM_SUBJECT=${subject.prefix:+${subject.prefix} }${subject.blob:+[${subject.blob}] }${subject.body}\nMM_MESSAGE_ID=${message-id.split}\n';
 	command       = '#!/bin/bash\n"${MM_BUNDLE_SUPPORT}/bin/create_instant_task"';
 	keyEquivalent = "^A";
-	uuid          = 'E7A70711-4924-4488-B37D-C8A784F05932';
+	uuid          = 'CC3CD952-9ED2-4945-A882-B333E0786E7B';
 }

--- a/Commands/Instant Add With Summary.mmCommand
+++ b/Commands/Instant Add With Summary.mmCommand
@@ -1,0 +1,8 @@
+{
+	name          = 'Instant Add With Summary...';
+	input         = 'canonical';
+	environment   = 'MM_FROM=${from}\nMM_SUBJECT=${subject.prefix:+${subject.prefix} }${subject.blob:+[${subject.blob}] }${subject.body}\nMM_MESSAGE_ID=${message-id.split}\n';
+	command       = '#!/bin/bash\n"${MM_BUNDLE_SUPPORT}/bin/create_instant_task"';
+	keyEquivalent = "^A";
+	uuid          = 'E7A70711-4924-4488-B37D-C8A784F05932';
+}

--- a/Support/bin/create_instant_task
+++ b/Support/bin/create_instant_task
@@ -1,0 +1,29 @@
+#!/usr/bin/ruby -w
+# encoding: UTF-8
+
+require 'cgi'
+
+# Create temporary file (don't use this execution style if user input is involved)
+tmpfilename = `mktemp -t add_input`.chop
+tmpfile = File.open(tmpfilename, "w+")
+
+# First line is used as the name of the task
+tmpfile.puts(ENV['MM_SUBJECT'])
+tmpfile.puts("message://%3c" + CGI::escape(ENV['MM_MESSAGE_ID']) + "%3e")
+
+# The rest is the note
+canonical = $stdin.read
+if !canonical.empty?
+  tmpfile.puts("From: " + ENV['MM_FROM'])
+  tmpfile.puts("Subject: " + ENV['MM_SUBJECT'])
+  tmpfile.puts("")
+  tmpfile.write(canonical)
+end
+
+tmpfile.close
+
+# Use AppleScript to communicate with the application
+system(ENV['MM_BUNDLE_SUPPORT'] + "/bin/create_instant_task_helper", tmpfilename)
+
+# Cleanup
+File.unlink(tmpfilename)

--- a/Support/bin/create_instant_task_helper
+++ b/Support/bin/create_instant_task_helper
@@ -1,0 +1,26 @@
+#!/usr/bin/osascript
+on run argv
+	set theFilename to item 1 of argv
+	set theLines to every paragraph of (do shell script ("cat " & theFilename))
+	set theName to item 1 of theLines
+	set theURL  to item 2 of theLines
+	try
+		set Applescript's text item delimiters to "\n"
+		set theNote to items 3 thru end of theLines as string
+	on error
+		set theNote to ""
+	end try
+
+	set theMessage to "[url=" & theURL & "]Email[/url]"
+
+	tell application id "com.culturedcode.ThingsMac"
+		-- Creating a todo without the quick entry:
+		set theToDo to make new to do at beginning of list "Inbox"
+		set name of theToDo to theName
+		set notes of theToDo to theMessage & "\n" & theNote
+		set tag names of theToDo to "Mail"
+
+		-- properties can include, for example, 'tag names:"Work"', but I couldn't make that work...
+		-- show quick entry panel with properties {name:theName, notes:theMessage & "\n" & theNote}
+	end tell
+end run


### PR DESCRIPTION
Added an 'Instant Add With Summary...' command to allow for the additional of an item directly to the Things inbox without prompting for user input. 
It also tags the action as 'Mail'

Please would you mind adding this to the main Things bundle as it would make using the bundle across multiple machines much easier. 
Thanks